### PR TITLE
tweaked data vis tooltips to ensure that singular 'project' is used w…

### DIFF
--- a/src/components/PortfolioShowcase/PortfolioDataVis/ps-tag-freq-chart.js
+++ b/src/components/PortfolioShowcase/PortfolioDataVis/ps-tag-freq-chart.js
@@ -106,7 +106,7 @@ const TagFrequencyChart = ({ entries }) => {
                 return (
                   <div className="bg-white border border-gray-200 p-2 shadow-lg rounded">
                     <p className="font-medium">{payload[0].payload.tag}</p>
-                    <p>Used in {payload[0].value} projects</p>
+                    <p>Used in {payload[0].value} project{payload[0].value > 1 && 's'}</p>
                   </div>
                 );
               }}


### PR DESCRIPTION
…hen there is only one project associated with the tech tag - example: 'php used in 1 project' whereas it previously showed 'php used in 1 projects'